### PR TITLE
Allow using a custom key to identify password reset tokens

### DIFF
--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -32,26 +32,6 @@ trait Authenticatable
     }
 
     /**
-     * Get the name of the login identifier for the user.
-     *
-     * @return string
-     */
-    public function getLoginIdentifierName()
-    {
-        return 'email';
-    }
-
-    /**
-     * Get the login identifier for the user.
-     *
-     * @return mixed
-     */
-    public function getLoginIdentifier()
-    {
-        return $this->{$this->getLoginIdentifierName()};
-    }
-
-    /**
      * Get the password for the user.
      *
      * @return string

--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -32,6 +32,26 @@ trait Authenticatable
     }
 
     /**
+     * Get the name of the login identifier for the user.
+     *
+     * @return string
+     */
+    public function getLoginIdentifierName()
+    {
+        return 'email';
+    }
+
+    /**
+     * Get the login identifier for the user.
+     *
+     * @return mixed
+     */
+    public function getLoginIdentifier()
+    {
+        return $this->{$this->getLoginIdentifierName()};
+    }
+
+    /**
      * Get the password for the user.
      *
      * @return string

--- a/src/Illuminate/Auth/Passwords/CanResetPassword.php
+++ b/src/Illuminate/Auth/Passwords/CanResetPassword.php
@@ -17,6 +17,26 @@ trait CanResetPassword
     }
 
     /**
+     * Get the name of the unique password reset identifier for the user.
+     *
+     * @return string
+     */
+    public function getPasswordResetIdentifierName()
+    {
+        return 'email';
+    }
+
+    /**
+     * Get the unique password reset identifier for the user.
+     *
+     * @return mixed
+     */
+    public function getPasswordResetIdentifier()
+    {
+        return $this->{$this->getPasswordResetIdentifierName()};
+    }
+
+    /**
      * Send the password reset notification.
      *
      * @param  string  $token

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -91,7 +91,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
         $token = $this->createNewToken();
 
         $this->getTable()->insert($this->getPayload(
-            $user->getLoginIdentifierName(), $user->getLoginIdentifier(), $token
+            $user->getPasswordResetIdentifierName(), $user->getPasswordResetIdentifier(), $token
         ));
 
         return $token;
@@ -106,7 +106,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     protected function deleteExisting(CanResetPasswordContract $user)
     {
         return $this->getTable()->where(
-            $user->getLoginIdentifierName(), $user->getLoginIdentifier()
+            $user->getPasswordResetIdentifierName(), $user->getPasswordResetIdentifier()
         )->delete();
     }
 
@@ -133,7 +133,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     public function exists(CanResetPasswordContract $user, $token)
     {
         $record = (array) $this->getTable()->where(
-            $user->getLoginIdentifierName(), $user->getLoginIdentifier()
+            $user->getPasswordResetIdentifierName(), $user->getPasswordResetIdentifier()
         )->first();
 
         return $record &&
@@ -161,7 +161,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     public function recentlyCreatedToken(CanResetPasswordContract $user)
     {
         $record = (array) $this->getTable()->where(
-            $user->getLoginIdentifierName(), $user->getLoginIdentifier()
+            $user->getPasswordResetIdentifierName(), $user->getPasswordResetIdentifier()
         )->first();
 
         return $record && $this->tokenRecentlyCreated($record['created_at']);

--- a/src/Illuminate/Contracts/Auth/CanResetPassword.php
+++ b/src/Illuminate/Contracts/Auth/CanResetPassword.php
@@ -12,6 +12,20 @@ interface CanResetPassword
     public function getEmailForPasswordReset();
 
     /**
+     * Get the name of the unique password reset identifier for the user.
+     *
+     * @return string
+     */
+    public function getPasswordResetIdentifierName();
+
+    /**
+     * Get the unique password reset identifier for the user.
+     *
+     * @return mixed
+     */
+    public function getPasswordResetIdentifier();
+
+    /**
      * Send the password reset notification.
      *
      * @param  string  $token

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Auth;
 
+use Illuminate\Auth\Authenticatable;
 use Illuminate\Auth\Passwords\DatabaseTokenRepository;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Hashing\Hasher;
@@ -36,8 +37,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
         $query->shouldReceive('insert')->once();
-        $user = m::mock(CanResetPassword::class);
-        $user->shouldReceive('getEmailForPasswordReset')->times(2)->andReturn('email');
+        $user = m::mock(new class implements CanResetPassword {
+            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
+        });
+        $user->shouldReceive('getLoginIdentifierName')->times(2)->andReturn('email');
+        $user->shouldReceive('getLoginIdentifier')->times(2)->andReturn('email');
 
         $results = $repo->create($user);
 
@@ -51,8 +55,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('first')->once()->andReturn(null);
-        $user = m::mock(CanResetPassword::class);
-        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+        $user = m::mock(new class implements CanResetPassword {
+            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
+        });
+        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'token'));
     }
@@ -64,8 +71,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subSeconds(300000)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(CanResetPassword::class);
-        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+        $user = m::mock(new class implements CanResetPassword {
+            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
+        });
+        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'token'));
     }
@@ -78,8 +88,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(CanResetPassword::class);
-        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+        $user = m::mock(new class implements CanResetPassword {
+            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
+        });
+        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
 
         $this->assertTrue($repo->exists($user, 'token'));
     }
@@ -92,8 +105,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(CanResetPassword::class);
-        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+        $user = m::mock(new class implements CanResetPassword {
+            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
+        });
+        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'wrong-token'));
     }
@@ -104,8 +120,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('first')->once()->andReturn(null);
-        $user = m::mock(CanResetPassword::class);
-        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+        $user = m::mock(new class implements CanResetPassword {
+            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
+        });
+        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
 
         $this->assertFalse($repo->recentlyCreatedToken($user));
     }
@@ -117,8 +136,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subSeconds(59)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(CanResetPassword::class);
-        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+        $user = m::mock(new class implements CanResetPassword {
+            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
+        });
+        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
 
         $this->assertTrue($repo->recentlyCreatedToken($user));
     }
@@ -130,8 +152,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subSeconds(61)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(CanResetPassword::class);
-        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+        $user = m::mock(new class implements CanResetPassword {
+            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
+        });
+        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
 
         $this->assertFalse($repo->recentlyCreatedToken($user));
     }
@@ -142,8 +167,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
-        $user = m::mock(CanResetPassword::class);
-        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+        $user = m::mock(new class implements CanResetPassword {
+            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
+        });
+        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
 
         $repo->delete($user);
     }

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Auth;
 
-use Illuminate\Auth\Authenticatable;
 use Illuminate\Auth\Passwords\DatabaseTokenRepository;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Hashing\Hasher;
@@ -37,11 +36,9 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
         $query->shouldReceive('insert')->once();
-        $user = m::mock(new class implements CanResetPassword {
-            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
-        });
-        $user->shouldReceive('getLoginIdentifierName')->times(2)->andReturn('email');
-        $user->shouldReceive('getLoginIdentifier')->times(2)->andReturn('email');
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getPasswordResetIdentifierName')->times(2)->andReturn('email');
+        $user->shouldReceive('getPasswordResetIdentifier')->times(2)->andReturn('email');
 
         $results = $repo->create($user);
 
@@ -53,13 +50,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
-        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $query->shouldReceive('where')->once()->with('username', 'username')->andReturn($query);
         $query->shouldReceive('first')->once()->andReturn(null);
-        $user = m::mock(new class implements CanResetPassword {
-            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
-        });
-        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
-        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getPasswordResetIdentifierName')->once()->andReturn('username');
+        $user->shouldReceive('getPasswordResetIdentifier')->once()->andReturn('username');
 
         $this->assertFalse($repo->exists($user, 'token'));
     }
@@ -71,11 +66,9 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subSeconds(300000)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(new class implements CanResetPassword {
-            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
-        });
-        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
-        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getPasswordResetIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getPasswordResetIdentifier')->once()->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'token'));
     }
@@ -85,14 +78,12 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->once()->with('token', 'hashed-token')->andReturn(true);
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
-        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $query->shouldReceive('where')->once()->with('uuid', 'uuid')->andReturn($query);
         $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(new class implements CanResetPassword {
-            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
-        });
-        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
-        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getPasswordResetIdentifierName')->once()->andReturn('uuid');
+        $user->shouldReceive('getPasswordResetIdentifier')->once()->andReturn('uuid');
 
         $this->assertTrue($repo->exists($user, 'token'));
     }
@@ -105,11 +96,9 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(new class implements CanResetPassword {
-            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
-        });
-        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
-        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getPasswordResetIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getPasswordResetIdentifier')->once()->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'wrong-token'));
     }
@@ -120,11 +109,9 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('first')->once()->andReturn(null);
-        $user = m::mock(new class implements CanResetPassword {
-            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
-        });
-        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
-        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getPasswordResetIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getPasswordResetIdentifier')->once()->andReturn('email');
 
         $this->assertFalse($repo->recentlyCreatedToken($user));
     }
@@ -136,11 +123,9 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subSeconds(59)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(new class implements CanResetPassword {
-            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
-        });
-        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
-        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getPasswordResetIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getPasswordResetIdentifier')->once()->andReturn('email');
 
         $this->assertTrue($repo->recentlyCreatedToken($user));
     }
@@ -152,11 +137,9 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subSeconds(61)->toDateTimeString();
         $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock(new class implements CanResetPassword {
-            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
-        });
-        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
-        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getPasswordResetIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getPasswordResetIdentifier')->once()->andReturn('email');
 
         $this->assertFalse($repo->recentlyCreatedToken($user));
     }
@@ -167,11 +150,9 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
-        $user = m::mock(new class implements CanResetPassword {
-            use \Illuminate\Auth\Passwords\CanResetPassword, Authenticatable;
-        });
-        $user->shouldReceive('getLoginIdentifierName')->once()->andReturn('email');
-        $user->shouldReceive('getLoginIdentifier')->once()->andReturn('email');
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getPasswordResetIdentifierName')->once()->andReturn('email');
+        $user->shouldReceive('getPasswordResetIdentifier')->once()->andReturn('email');
 
         $repo->delete($user);
     }


### PR DESCRIPTION
This PR replaces the hard-coded `'email'` key in the `DatabaseTokenRepository` so that developers can specify a custom field to use as the unique identifier for password reset tokens.

The use case for this feature is any app where email addresses are not the 'login' identifier, where there is no `email` column, or where emails are not necessarily unique; for example:

1. Legacy apps where the email address column is not called `email` (and there may not be a column called `email` at all). Technically I think this would still work, but it could get confusing because the column names on the user and password reset tables won't match. See laravel/ideas#1541 and https://laracasts.com/discuss/channels/laravel/email-column-name-different-for-password-reset.
2. Apps that don't use email addresses for authentication. It's still pretty common to want to use usernames for authentication, and if an app uses `username` and `password` for all authentication it makes sense to also track password reset tokens using the `username` value. Although this is less common, it's also possible for an app not to collect email addresses at all.
3. Apps where `email` is not unique across all user records. This is my current use case—our unique user identifier is `username`, and users may have multiple accounts over time with new usernames but the same email address. We'd like to be able to store password resets using a `username` column instead of `email`, without re-implement the entire token repository.

...

It will still be up to the developer to update the `password_resets` table to use the configured identifier.